### PR TITLE
Fix: Improve Netflix title detection in zoomed/preview mode.

### DIFF
--- a/content.js
+++ b/content.js
@@ -104,6 +104,11 @@ class MovieRatingsTooltip {
       '.title-card',
       '.slider-item',
       '.title-card-container',
+      // New selectors for Netflix expanded preview
+      '.previewModal--player-titleArea h1',
+      '[data-uia="previewModal-title"]',
+      '.bob-title',
+      '.title.episode-title',
       
       // HBO Max
       '.content-tile',


### PR DESCRIPTION
When Netflix displays a larger preview of a movie or series with autoplay, the DOM structure changes, and the previous selectors were not always able to identify the movie title.

This commit introduces new CSS selectors to `findMovieElement` in `content.js` specifically targeting elements within this zoomed/preview modal on Netflix. The new selectors include:
- '.previewModal--player-titleArea h1'
- '[data-uia="previewModal-title"]'
- '.bob-title'
- '.title.episode-title'

These additions should allow the extension to correctly find and display ratings for titles viewed in Netflix's zoomed preview interface. The existing functionality for other views on Netflix and other supported websites remains unaffected.